### PR TITLE
Fix Page Title 

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
  	</script>
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1.0">
-  <title>index</title>
+  <title>Csoup - Home</title>
   <link href="http://fonts.googleapis.com/css?family=Montserrat:400" rel="stylesheet" type="text/css">
   <script type="text/javascript" src="http://use.typekit.net/asd4pio.js"></script>
   <script type="text/javascript">try{Typekit.load();}catch(e){}</script>


### PR DESCRIPTION
This will fix the page title, which is currently "index" and not the page name or site name.